### PR TITLE
Add an options table so we can choose to return a default

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -820,8 +820,7 @@ local default_icon = {
 }
 
 return {
-  default_icon = default_icon,
-  get_icon = function(name, ext)
+  get_icon = function(name, ext, opts)
     local icon_data = icons[name]
     local by_name = icon_data and icon_data.icon or nil
 
@@ -829,6 +828,9 @@ return {
       return by_name, get_highlight_name(icon_data)
     else
       icon_data = icons[ext]
+      if opts and opts.default and not icon_data then
+        icon_data = default_icon
+      end
       if icon_data then
         local by_ext = icon_data.icon
         return by_ext, get_highlight_name(icon_data)
@@ -836,7 +838,7 @@ return {
     end
   end,
   setup = function()
-    table.insert(icons, 0, default_icon)
+    table.insert(icons, default_icon)
     for _, icon_data in pairs(icons) do
       if icon_data.color and icon_data.name then
         local hl_group = get_highlight_name(icon_data)


### PR DESCRIPTION
@kyazdani42 this PR changes the way we handle the default icon, it adds in a 3rd optional argument to `get_icon` which are options. For now the only option is `default = boolean` if true then the get icon will return the default icon if none if found. This way a user can still opt not to return a default.

so usage will be
```lua
-- No default
require'nvim-web-devicons'.get_icon("filename.js", "js")

-- Or with default
require'nvim-web-devicons'.get_icon("filename.js", "js", { default = true })
```

I think this is preferable to just removing it and adding the default to exports because by removing it it means you won't be able to get the `highlight name` for the default icon. The default icon's name is `Default` but the highlight group is added when `get_highlight_name` is called so it's actually `DefaultDevIcon` which someone won't know unless they check the code. If they do hard code this though then if we change the way names are created people using this will have to change their plugins to match the new name.

Also in `bufferline.lua` it means I have to do `nil` checks manually then add and highlight the default icon and group as well