### PR TITLE
Fix svg icon key name

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -82,18 +82,13 @@ local icons = {
     color = "#596706",
     name = "Cs",
   },
-  ["jl"] = {
-    icon = "",
-    color = "#a074c4",
-    name = "Jl"
-  },
   ["procfile"] = {
     icon = "",
     color = "#a074c4",
     name = "Procfile"
   },
   ["svg"] = {
-    code = "ﰟ",
+    icon = "ﰟ",
     color = "#FFB13B",
     name = "Svg",
   },


### PR DESCRIPTION
@kyazdani42 this was causing the plugin to break in svg files as the icon key was
incorrectly named but being accessed. As for the other icon I removed that was a duplicate I didn't notice when I made the original PR