### PR TITLE
feat: option to globally enable default icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ require'nvim-web-devicons'.setup {
   }
  };
  -- globally enable default icons (default to false)
- -- takes precedence over `get_icon` options
+ -- will get overriden by `get_icons` option
  default = true;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ if the color scheme changes
 require'nvim-web-devicons'.setup {
  -- your personnal icons can go here (to override)
  -- DevIcon will be appended to `name`
+ override = {
   zsh = {
     icon = "",
     color = "#428850",
     name = "Zsh"
-  };
+  }
+ };
+ -- globally enable default icons (default to false)
+ -- takes precedence over `get_icon` options
+ default = true;
 }
 ```
 

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -824,6 +824,11 @@ local default_icon = {
   name = "Default",
 }
 
+local global_opts = {
+  override = {},
+  default = false
+}
+
 return {
   get_icon = function(name, ext, opts)
     local icon_data = icons[name]
@@ -833,17 +838,27 @@ return {
       return by_name, get_highlight_name(icon_data)
     else
       icon_data = icons[ext]
-      if opts and opts.default and not icon_data then
+
+      if global_opts and global_opts.default and not icon_data then
+        icon_data = default_icon
+      elseif opts and opts.default and not icon_data then
         icon_data = default_icon
       end
+
       if icon_data then
         local by_ext = icon_data.icon
         return by_ext, get_highlight_name(icon_data)
       end
     end
   end,
-  setup = function(user_icons)
-    icons = vim.tbl_extend("force", icons, user_icons or {});
+  setup = function(opts)
+    local user_icons = opts and opts.override or {}
+
+    if global_opts and not global_opts.default then
+      global_opts.default = opts and opts.default or false
+    end
+
+    icons = vim.tbl_extend("force", icons, user_icons);
 
     table.insert(icons, default_icon)
     for _, icon_data in pairs(icons) do

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -839,9 +839,7 @@ return {
     else
       icon_data = icons[ext]
 
-      if global_opts and global_opts.default and not icon_data then
-        icon_data = default_icon
-      elseif opts and opts.default and not icon_data then
+      if (global_opts.default or (opts and opts.default)) and not icon_data then
         icon_data = default_icon
       end
 
@@ -852,13 +850,13 @@ return {
     end
   end,
   setup = function(opts)
-    local user_icons = opts and opts.override or {}
+    local user_icons = opts or {}
 
-    if global_opts and not global_opts.default then
-      global_opts.default = opts and opts.default or false
+    if user_icons.default then
+      global_opts.default = true
     end
 
-    icons = vim.tbl_extend("force", icons, user_icons);
+    icons = vim.tbl_extend("force", icons, user_icons.override);
 
     table.insert(icons, default_icon)
     for _, icon_data in pairs(icons) do


### PR DESCRIPTION
This will allow user to enable default icon globally. It will benefit plugins like [telescope](https://github.com/nvim-lua/telescope.nvim) (and some other plugins who uses devicons) so you don't have to configure it for each plugin.