### PR TITLE
fix: adjust c-lang color

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -209,7 +209,7 @@ local icons = {
   };
   ["c"] = {
     icon = "",
-    color = "#555555",
+    color = "#599eff",
     name = "C"
   };
   ["c++"] = {


### PR DESCRIPTION
C currently has a grey shade associated to it. It's probably best to not give unsaturated colors to primary languages (as opposed to config files such as gitignore, makefile, etc) because next to a saturated color, it doesn't carry the fact that both informations have the same importance.

Before:
![Screenshot from 2020-10-28 10-21-05](https://user-images.githubusercontent.com/1423607/97449304-e73e0900-1907-11eb-83ef-2a65f515dce2.png)
After:
![Screenshot from 2020-10-28 10-24-31](https://user-images.githubusercontent.com/1423607/97449312-e86f3600-1907-11eb-8f92-8d2171bda66e.png)
