### PR TITLE
Add color for .gitlab-ci.yml

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -134,7 +134,7 @@ local icons = {
   };
   [".gitlab-ci.yml"] = {
     icon = "",
-    color = "#41535b",
+    color = "#e24329",
     name = "GitlabCI"
   };
   [".gvimrc"] = {


### PR DESCRIPTION
Adds an orange tint (taken directly from the GitLab logo) to the `.gitlab-ci.yml` icon.