### PR TITLE
feat: allow importing all icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,13 @@ You can check if the setup function was already called with:
 ```lua
 require'nvim-web-devicons'.has_loaded()
 ```
+
+### Get all icons
+
+It is possible to get all of the registered icons with the `get_icons()` function:
+
+```lua
+require'nvim-web-devicons'.get_icons()
+```
+
+This can be useful for debugging purposes or for creating custom highlights for each icon.

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -920,4 +920,5 @@ return {
   get_icon = get_icon,
   setup = setup,
   has_loaded = function() return loaded end,
+  get_icons = function() return icons end,
 }


### PR DESCRIPTION
Hey!

I would like to import all of the icons in my configuration. The use case is to create my own highlight groups for the statusline with a background color:

```lua
local icons = require('nvim-web-devicons').get_icons()
for _, icon_data in pairs(icons) do
  if icon_data.color and icon_data.name then
    local hl_group = icon_data.name and 'StatuslineDevIcon' .. icon_data.name
    if hl_group then
      vim.api.nvim_command("highlight! "..hl_group.. " guifg="..icon_data.color.." guibg="..statusline_background)
    end
  end
end
```

What do you think of this? Should I add the `get_icons` function to the docs, or is it okay to keep it a "hidden" feature?