### PR TITLE
Avoid highlights being overridden when setting a colorscheme after setup()

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -864,6 +864,17 @@ local function get_highlight_name(data)
   return data.name and "DevIcon" .. data.name
 end
 
+local function set_up_highlights()
+  for _, icon_data in pairs(icons) do
+    if icon_data.color and icon_data.name then
+      local hl_group = get_highlight_name(icon_data)
+      if hl_group then
+        vim.api.nvim_command("highlight! "..hl_group.. " guifg="..icon_data.color)
+      end
+    end
+  end
+end
+
 local loaded = false
 
 local function setup(opts)
@@ -882,14 +893,13 @@ local function setup(opts)
   icons = vim.tbl_extend("force", icons, user_icons.override or {});
 
   table.insert(icons, default_icon)
-  for _, icon_data in pairs(icons) do
-    if icon_data.color and icon_data.name then
-      local hl_group = get_highlight_name(icon_data)
-      if hl_group then
-        vim.api.nvim_command("highlight! "..hl_group.. " guifg="..icon_data.color)
-      end
-    end
-  end
+
+  set_up_highlights()
+
+  vim.cmd [[augroup NvimWebDevicons]]
+  vim.cmd [[autocmd!]]
+  vim.cmd [[autocmd ColorScheme * lua require('nvim-web-devicons').set_up_highlights()]]
+  vim.cmd [[augroup END]]
 end
 
 local function get_icon(name, ext, opts)
@@ -921,4 +931,5 @@ return {
   setup = setup,
   has_loaded = function() return loaded end,
   get_icons = function() return icons end,
+  set_up_highlights = set_up_highlights,
 }


### PR DESCRIPTION
Hey!

Colorschemes usually run `highlight clear` to clear all highlights before applying their own. This means that if the colorscheme is changed *after* this plugin is initialized, all highlight groups would be lost.

The solution would be to also create the highlights as a response to the `ColorScheme` `autocmd`.

Example of the problem:

https://user-images.githubusercontent.com/9450943/113504038-413d9d00-953e-11eb-8f7d-b68c2471dfe1.mov

Does this solution make sense for this plugin? Also, I wasn't sure if I should wrap the `autocmd` in an `augroup` or not in this case. What do you think?