### PR TITLE
Fix CMake icon

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -247,10 +247,15 @@ local icons = {
     color = "#519aba",
     name = "ClojureJS",
   };
-  ["cmakelists.txt"] = {
+  ["CMakeLists.txt"] = {
     icon = "",
     color = "#6d8086",
-    name = "CmakeLists"
+    name = "CMakeLists"
+  };
+  ["cmake"] = {
+    icon = "",
+    color = "#6d8086",
+    name = "CMake"
   };
   ["coffee"] = {
     icon = "",


### PR DESCRIPTION
`CMakeLists.txt` had an incorrect case (what caused the default icon on Linux).
Also I added `cmake` rule for `.cmake` files (CMake scripts).