### PR TITLE
Add COPYING license icon

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -137,6 +137,16 @@ local icons = {
     color = "#41535b",
     name = "GitCommit"
   };
+  ["COPYING"] = {
+    icon = "",
+    color = "#cbcb41",
+    name = "License",
+  };
+  ["COPYING.LESSER"] = {
+    icon = "",
+    color = "#cbcb41",
+    name = "License",
+  };
   [".gitlab-ci.yml"] = {
     icon = "",
     color = "#e24329",


### PR DESCRIPTION
[Such names](https://www.gnu.org/licenses/gpl-howto.html) are commonly used for the GPL license.