### PR TITLE
Add icons for the .sml and .sig file extensions used by Standard ML

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -762,6 +762,11 @@ local icons = {
     color = "#4d5a5e",
     name = "Sh"
   };
+  ["sig"] = {
+    icon = "λ",
+    color = "#e37933",
+    name = "Sig"
+  };
   ["slim"] = {
     icon = "",
     color = "#e34c26",
@@ -771,6 +776,11 @@ local icons = {
     icon = "",
     color = "#854CC7",
     name = "Sln"
+  };
+  ["sml"] = {
+    icon = "λ",
+    color = "#e37933",
+    name = "Sml"
   };
   ["sql"] = {
     icon = "",


### PR DESCRIPTION
The colors and icons are the same as for the OCaml's `.ml` and `.mli` files.