### PR TITLE
Add icon for Crystal

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -307,6 +307,11 @@ local icons = {
     color = "#519aba",
     name = "Cpp",
   };
+  ["cr"] = {
+    icon = "",
+    color = "#000000",
+    name = "Crystal",
+  };
   ["csh"] = {
     icon = "",
     color = "#4d5a5e",


### PR DESCRIPTION
There isn't a proper icon in nerdfont yet, so just using a black
hexagon, which is pretty close to the favicon on
https://crystal-lang.org though not at the correct angle.