### PR TITLE
Fix bug caused by multiple setup calls clobbering icon map names

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1018,6 +1018,8 @@ end
 local loaded = false
 
 local function setup(opts)
+  if loaded then return end
+
   loaded = true
 
   local user_icons = opts or {}


### PR DESCRIPTION
Simple fix that was causing a lot of problems with another plugin, fzf-lua, and probably others.  If setup gets called multiple times, the icon map names can get clobbered and quit matching extensions properly.