### PR TITLE
feat: use only the file name tail in function 'get_icon'

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1053,6 +1053,7 @@ local function get_icon(name, ext, opts)
     setup()
   end
 
+  name = vim.fn.fnamemodify(name, ':t')
   local has_default = (opts and opts.default) or global_opts.default
   local icon_data = icons[name] or icons[ext] or (has_default and default_icon)
 


### PR DESCRIPTION
This makes the function ```get_icon``` return icons consistently when the 'name' parameter passed is a path with other directories, not only the file name. the build in function [fnamemodify](https://neovim.io/doc/user/eval.html#fnamemodify()) removes other parts of the path, leaving only the file name before searching for the icon in the icons table.

@kyazdani42 do you have a way of measure the performance hit of calling ```vim.fn.fnamemodify```?

fix #84