### PR TITLE
add icon for .heex (Elixir's HTML EEx)

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -482,6 +482,11 @@ local icons = {
     color = "#f0772b",
     name = "Hbs",
   };
+  ["heex"] = {
+    icon = "",
+    color = "#a074c4",
+    name = "Heex",
+  };
   ["hh"] = {
     icon = "",
     color = "#a074c4",


### PR DESCRIPTION
Until recently, `.leex` was the preferred template for rendering HTML for Phoenix LiveView. A new format, `.heex`, is now the preferred format. This PR adds support for that filetype, following the existing configuration for `.leex` files.

![image](https://user-images.githubusercontent.com/18172185/136274997-69cf628c-017f-46b8-8984-88b3ed51ea09.png)

ref: https://hexdocs.pm/phoenix_live_view/assigns-eex.html