### PR TITLE
Add icon for .nim

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1236,6 +1236,12 @@ local icons = {
     cterm_color = "108",
     name = "Mint",
   },
+  ["nim"] = {
+    icon = "👑",
+    color = "#f3d400",
+    cterm_color = "220",
+    name = "Nim",
+  },
 }
 
 local default_icon = {


### PR DESCRIPTION
Description:
Nim is a statically typed compiled systems programming language. It combines successful concepts from mature languages like Python, Ada and Modula.
WWW: https://nim-lang.org/

The nim's logo is a [gold crown](https://nim-lang.org/assets/img/logo.svg), so I used the crown Unicode symbol, with the standard color of nim, and “gold” color for cterm.

Thanks. 