### PR TITLE
feat: get icons by filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,18 @@ You can override the default icon with the `set_default_icon(icon, color)` funct
 ```lua
 require("nvim-web-devicons").set_default_icon('', '#6d8086')
 ```
+
+### Getting icons by filetype
+
+You can get the icon and colors associated with a filetype using the `by_filetype` functions:
+
+```lua
+require("nvim-web-devicons").get_icon_by_filetype(filetype, opts)
+require("nvim-web-devicons").get_icon_colors_by_filetype(filetype, opts)
+require("nvim-web-devicons").get_icon_color_by_filetype(filetype, opts)
+require("nvim-web-devicons").get_icon_cterm_color_by_filetype(filetype, opts)
+```
+
+These functions are the same as their counterparts without the `_by_filetype` suffix, but they take a filetype instead of a name/extension.
+
+You can also use `get_icon_name_by_filetype(filetype)` to get the icon name associated with the filetype.

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -31,6 +31,7 @@
 --   color = "#ffa61a"
 -- },
 
+-- When adding new icons, remember to add an entry to the `filetypes` table, if applicable.
 local icons = {
   [".babelrc"] = {
     icon = "ﬥ",
@@ -1272,6 +1273,161 @@ local icons = {
   },
 }
 
+-- Map of filetypes -> icon names
+local filetypes = {
+  ["Brewfile"] = "Brewfile",
+  ["COMMIT"] = "COMMIT_EDITMSG",
+  ["COPYING"] = "COPYING",
+  ["Gemfile"] = "Gemfile$",
+  ["LESSER"] = "COPYING.LESSER",
+  ["LICENSE"] = "LICENSE",
+  ["Vagrantfile"] = "Vagrantfile$",
+  ["awk"] = "awk",
+  ["bmp"] = "bmp",
+  ["c"] = "c",
+  ["cfg"] = "cfg",
+  ["clojure"] = "clj",
+  ["cmake"] = "cmake",
+  ["cobol"] = "cobol",
+  ["coffee"] = "coffee",
+  ["conf"] = "conf",
+  ["cp"] = "cp",
+  ["cpp"] = "cpp",
+  ["cr"] = "cr",
+  ["cs"] = "cs",
+  ["csh"] = "csh",
+  ["cson"] = "cson",
+  ["css"] = "css",
+  ["csv"] = "csv",
+  ["d"] = "d",
+  ["dart"] = "dart",
+  ["desktop"] = "desktop",
+  ["diff"] = "diff",
+  ["doc"] = "doc",
+  ["dockerfile"] = "dockerfile",
+  ["dosbatch"] = "bat",
+  ["dosini"] = "ini",
+  ["dropbox"] = "dropbox",
+  ["dump"] = "dump",
+  ["eex"] = "eex",
+  ["ejs"] = "ejs",
+  ["elixir"] = "ex",
+  ["elm"] = "elm",
+  ["epuppet"] = "epp",
+  ["erlang"] = "erl",
+  ["eruby"] = "erb",
+  ["fennel"] = "fnl",
+  ["fish"] = "fish",
+  ["forth"] = "fs",
+  ["fortran"] = "f#",
+  ["fsi"] = "fsi",
+  ["fsscript"] = "fsscript",
+  ["fsx"] = "fsx",
+  ["gd"] = "gd",
+  ["gif"] = "gif",
+  ["git"] = "git",
+  ["gitconfig"] = ".gitconfig",
+  ["glb"] = "glb",
+  ["go"] = "go",
+  ["godot"] = "godot",
+  ["gruntfile"] = "gruntfile",
+  ["gulpfile"] = "gulpfile",
+  ["haml"] = "haml",
+  ["haskell"] = "hs",
+  ["hbs"] = "hbs",
+  ["heex"] = "heex",
+  ["html"] = "html",
+  ["ico"] = "ico",
+  ["idlang"] = "pro",
+  ["import"] = "import",
+  ["java"] = "java",
+  ["javascript"] = "js",
+  ["javascript.jsx"] = "jsx",
+  ["javascriptreact"] = "jsx",
+  ["jpeg"] = "jpeg",
+  ["jpg"] = "jpg",
+  ["json"] = "json",
+  ["julia"] = "jl",
+  ["kotlin"] = "kt",
+  ["leex"] = "leex",
+  ["less"] = "less",
+  ["lhaskell"] = "lhs",
+  ["license"] = "license",
+  ["lprolog"] = "sig",
+  ["lua"] = "lua",
+  ["make"] = "makefile",
+  ["markdown"] = "markdown",
+  ["material"] = "material",
+  ["mdx"] = "mdx",
+  ["mint"] = "mint",
+  ["mustache"] = "mustache",
+  ["nim"] = "nim",
+  ["nix"] = "nix",
+  ["node"] = "node_modules",
+  ["ocaml"] = "ml",
+  ["opus"] = "opus",
+  ["otf"] = "otf",
+  ["pck"] = "pck",
+  ["pdf"] = "pdf",
+  ["perl"] = "pl",
+  ["php"] = "php",
+  ["plaintex"] = "tex",
+  ["png"] = "png",
+  ["postscr"] = "ai",
+  ["ppt"] = "ppt",
+  ["procfile"] = "procfile",
+  ["ps1"] = "ps1",
+  ["psb"] = "psb",
+  ["psd"] = "psd",
+  ["puppet"] = "pp",
+  ["pyc"] = "pyc",
+  ["pyd"] = "pyd",
+  ["pyo"] = "pyo",
+  ["python"] = "py",
+  ["r"] = "r",
+  ["rlib"] = "rlib",
+  ["rmd"] = "rmd",
+  ["rproj"] = "rproj",
+  ["ruby"] = "rb",
+  ["rust"] = "rs",
+  ["sass"] = "sass",
+  ["scala"] = "scala",
+  ["scss"] = "scss",
+  ["sh"] = "sh",
+  ["slim"] = "slim",
+  ["sln"] = "sln",
+  ["sml"] = "sml",
+  ["solidity"] = "sol",
+  ["sql"] = "sql",
+  ["sqlite"] = "sqlite",
+  ["sqlite3"] = "sqlite3",
+  ["styl"] = "styl",
+  ["sublime"] = "sublime",
+  ["suo"] = "suo",
+  ["svelte"] = "svelte",
+  ["svg"] = "svg",
+  ["swift"] = "swift",
+  ["tads"] = "t",
+  ["terminal"] = "terminal",
+  ["toml"] = "toml",
+  ["tres"] = "tres",
+  ["tscn"] = "tscn",
+  ["twig"] = "twig",
+  ["txt"] = "txt",
+  ["typescript"] = "ts",
+  ["typescriptreact"] = "tsx",
+  ["vim"] = "vim",
+  ["vue"] = "vue",
+  ["webp"] = "webp",
+  ["webpack"] = "webpack",
+  ["xcplayground"] = "xcplayground",
+  ["xls"] = "xls",
+  ["xml"] = "xml",
+  ["yaml"] = "yaml",
+  ["zig"] = "zig",
+  ["zsh"] = "zsh",
+}
+
 local default_icon = {
   icon = "",
   color = "#6d8086",
@@ -1371,6 +1527,18 @@ local function get_icon(name, ext, opts)
   end
 end
 
+local function get_icon_name_by_filetype(ft)
+  return filetypes[ft]
+end
+
+local function get_icon_by_filetype(ft, opts)
+  local name = get_icon_name_by_filetype(ft)
+  if name == nil then
+    return
+  end
+  return get_icon(name, nil, opts)
+end
+
 local function get_icon_colors(name, ext, opts)
   ext = ext or name:match("^.*%.(.*)$") or ""
   if not loaded then
@@ -1385,14 +1553,38 @@ local function get_icon_colors(name, ext, opts)
   end
 end
 
+local function get_icon_colors_by_filetype(ft, opts)
+  local name = get_icon_name_by_filetype(ft)
+  if name == nil then
+    return
+  end
+  return get_icon_colors(name, nil, opts)
+end
+
 local function get_icon_color(name, ext, opts)
   local data = { get_icon_colors(name, ext, opts) }
   return data[1], data[2]
 end
 
+local function get_icon_color_by_filetype(ft, opts)
+  local name = get_icon_name_by_filetype(ft)
+  if name == nil then
+    return
+  end
+  return get_icon_color(name, nil, opts)
+end
+
 local function get_icon_cterm_color(name, ext, opts)
   local data = { get_icon_colors(name, ext, opts) }
   return data[1], data[3]
+end
+
+local function get_icon_cterm_color_by_filetype(ft, opts)
+  local name = get_icon_name_by_filetype(ft)
+  if name == nil then
+    return
+  end
+  return get_icon_cterm_color(name, nil, opts)
 end
 
 local function set_icon(user_icons)
@@ -1414,6 +1606,11 @@ return {
   get_icon_colors = get_icon_colors,
   get_icon_color = get_icon_color,
   get_icon_cterm_color = get_icon_cterm_color,
+  get_icon_name_by_filetype = get_icon_name_by_filetype,
+  get_icon_by_filetype = get_icon_by_filetype,
+  get_icon_colors_by_filetype = get_icon_colors_by_filetype,
+  get_icon_color_by_filetype = get_icon_color_by_filetype,
+  get_icon_cterm_color_by_filetype = get_icon_cterm_color_by_filetype,
   set_icon = set_icon,
   set_default_icon = set_default_icon,
   setup = setup,


### PR DESCRIPTION
Adds the `filetypes` table, which is a map from vim filetypes to icon names.

```lua
local filetypes = {
  ["Brewfile"] = "Brewfile",
  ["COMMIT"] = "COMMIT_EDITMSG",
  ["COPYING"] = "COPYING",
  -- ...
  ["yaml"] = "yaml",
  ["zig"] = "zig",
  ["zsh"] = "zsh",
}
```

The map is not exhaustive. More filetypes should be added over time, but at least this is a start.

Also adds the following functions:

```lua
get_icon_by_filetype(filetype, opts)
get_icon_colors_by_filetype(filetype, opts)
get_icon_color_by_filetype(filetype, opts)
get_icon_cterm_color_by_filetype(filetype, opts)
get_icon_name_by_filetype(filetype)
``` 

Because some icons are not distinguishable by their filetype alone, the filetype table maps to the "most common" or "canonical" icon. E.g. the filetype `cpp` maps to the `cpp` icon, even though `.hpp` files also have the `cpp` filetype. 

For this reason, **users should prefer the standard `get_icon` function if the filename is known**; the `get_icon_name_by_filetype` function should only be used if the filename is unknown.

---

P.s. if you're interested, I wrote this script to assist in generating the `filetypes` table, and then manually cleaned up the results.

```sh
#!/usr/bin/env bash
set -euo pipefail

function get_icon_names() {
  curl 'https://raw.githubusercontent.com/kyazdani42/nvim-web-devicons/master/lua/nvim-web-devicons.lua' |
    lua -e '
      pats={}
      for name in pairs(dofile().get_icons()) do
        table.insert(pats, name)
      end
      table.sort(pats)
      print(table.concat(pats, "\n"))
    '
}

function main() {
  local tmp
  tmp="$(mktemp -d)"
  # shellcheck disable=2064
  trap "rmdir '$tmp'" EXIT
  cd "$tmp"
  local file
  local -A filetypes=()
  local -a missing=()
  while read -r pat; do
    echo "$pat" >&2
    if [[ "$pat" =~ ^\. ]]; then
      file="$pat"
    else
      file="test.$pat"
    fi
    touch "./$file"
    local ft
    ft="$(/usr/bin/nvim -u NORC --noplugin --headless "./$file" +'lua
      local ok, err = pcall(vim.fn.writefile, { vim.bo.filetype }, "/dev/stdout")
      if not ok then
        print(err .. "\n")
        vim.cmd "cquit"
      end
      vim.cmd "quit"
    ')"
    rm "./$file"
    if [[ -n "$ft" ]]; then
      if [[ -v filetypes["$ft"] ]]; then
        filetypes["$ft"]="${filetypes["$ft"]}, '$pat'"
      else
        filetypes["$ft"]="'$pat'"
      fi
    else
      missing+=("$pat")
    fi
  done < <(get_icon_names)

  echo "local filetypes = {"
  for ft in "${!filetypes[@]}"; do
    echo "  ['$ft'] = { ${filetypes[$ft]} },"
  done
  echo "}"
  echo
  echo "local missing = {"
  printf "  '%s',\n" "${missing[@]}"
  echo "}"
}

main "$@"
```

Ref #29