### PR TITLE
added light pink brain icon for Drools Rules Language (.drl)

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -435,6 +435,12 @@ local icons = {
     cterm_color = "59",
     name = "Dockerfile",
   },
+  ["drools"] = {
+    icon = "",
+    color = "#ffafaf",
+    cterm_color = "217",
+    name = "Drools",
+  },
   ["dropbox"] = {
     icon = "",
     color = "#0061FE",
@@ -1373,6 +1379,7 @@ local filetypes = {
   ["dockerfile"] = "dockerfile",
   ["dosbatch"] = "bat",
   ["dosini"] = "ini",
+  ["drools"] = "drl",
   ["dropbox"] = "dropbox",
   ["dump"] = "dump",
   ["eex"] = "eex",


### PR DESCRIPTION
Signed-off-by: David Ward <dward@redhat.com>

I chose a brain [1] icon because Drools [2] is a business intelligence rules engine language (of which I am the team's engineering manager at Red Hat). I wish Nerd Fonts had an actual "Drools" logo, but alas, it doesn't.

I chose a light pink [3] color because it will stand out better on light or dark backgrounds than using a white or gray color, I think. But I'd listen to other suggestions that might be better.

[1] search for "nf-fae-brain" here: https://www.nerdfonts.com/cheat-sheet
[2] https://www.drools.org/
[3] search for "LightPink1" here: https://www.ditig.com/256-colors-cheat-sheet