### PR TITLE
fixed drools filetype to drools icon (extension) mapping

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -435,7 +435,7 @@ local icons = {
     cterm_color = "59",
     name = "Dockerfile",
   },
-  ["drools"] = {
+  ["drl"] = {
     icon = "",
     color = "#ffafaf",
     cterm_color = "217",


### PR DESCRIPTION
Signed-off-by: David Ward <dward@redhat.com>

This is a follow-up to https://github.com/kyazdani42/nvim-web-devicons/pull/136 , which admittedly I messed up testing the plugin correctly by having mixed-up paths. I have verified this is now correct. Apologies.