### PR TITLE
Added partial compatibility layer with the original devicons

### DIFF
--- a/plugin/nvim-web-devicons.vim
+++ b/plugin/nvim-web-devicons.vim
@@ -10,3 +10,23 @@ let &cpo = s:save_cpo
 unlet s:save_cpo
 
 let g:loaded_devicons = 1
+
+" compatibility with vim-devicons, so VimScript-only plugins can check if the
+" function exists and don't care if it comes from vim-devicons or this plugin
+function! WebDevIconsGetFileTypeSymbol(name, ext = "")
+
+    if empty(a:ext)
+        let l:extension = getbufvar(a:name, "&filetype", "")
+    else
+        let l:extension = a:ext
+    endif
+
+    let l:icon = luaeval("require('nvim-web-devicons').get_icon(\""..a:name.."\", \""..l:extension.."\")")
+
+    if l:icon == "null"
+        return ""
+    else
+        return l:icon
+    endif
+
+endfunction


### PR DESCRIPTION
Implemented a wrapper function WebDevIconsGetFileTypeSymbol() to be used by VimScript plugins that expect [original devicons](https://github.com/ryanoasis/vim-devicons) to be installed.