### PR TITLE
default = false local override fix

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1639,7 +1639,7 @@ local function get_icon(name, ext, opts)
     setup()
   end
 
-  local has_default = (opts and opts.default) or global_opts.default
+  local has_default = vim.F.if_nil(opts and opts.default, global_opts.default)
   local icon_data = icons[name] or icons[ext] or (has_default and default_icon)
 
   if icon_data then
@@ -1662,7 +1662,7 @@ local function get_icon_colors(name, ext, opts)
     setup()
   end
 
-  local has_default = (opts and opts.default) or global_opts.default
+  local has_default = vim.F.if_nil(opts and opts.default, global_opts.default)
   local icon_data = icons[name] or icons[ext] or (has_default and default_icon)
 
   if icon_data then


### PR DESCRIPTION
Previously `opts.default = false` gets overridden by `global_opts.default = true`
Now `opts.default` always overrides `global_opts.default`