### PR TITLE
Icons: Add GraphQL support

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -596,6 +596,12 @@ local icons = {
     cterm_color = "66",
     name = "GodotProject",
   },
+  ["graphql"] = {
+    icon = "",
+    color = "#e535ab",
+    cterm_color = "199",
+    name = "GraphQL"
+  },
   ["gruntfile"] = {
     icon = "",
     color = "#e37933",
@@ -1433,6 +1439,7 @@ local filetypes = {
   ["glb"] = "glb",
   ["go"] = "go",
   ["godot"] = "godot",
+  ["graphql"] = "graphql",
   ["gruntfile"] = "gruntfile",
   ["gulpfile"] = "gulpfile",
   ["haml"] = "haml",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -597,7 +597,7 @@ local icons = {
     name = "GodotProject",
   },
   ["graphql"] = {
-    icon = "",
+    icon = "",
     color = "#e535ab",
     cterm_color = "199",
     name = "GraphQL"


### PR DESCRIPTION
So, this isn't quite ideal since nerd fonts don't include the GraphQL logo, but i was tired of seeing the default icon for my gql file and decided to do something about it.

This solution is basically just a recoloured react icon, but given that they are reasonably close you actively have to look to tell, which shouldn't much of an issue on reasonable font sizes.

If you don't think this should be core, I'll gladly leave it as a local tweak in my config :)