### PR TITLE
Add `query` icon

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1013,6 +1013,12 @@ local icons = {
     cterm_color = "67",
     name = "Pyo",
   },
+  ["query"] = {
+    icon = "",
+    color = "#90a850",
+    cterm_color = "154",
+    name = "Query",
+  },
   ["r"] = {
     icon = "ﳒ",
     color = "#358a5b",
@@ -1511,6 +1517,7 @@ local filetypes = {
   ["pyd"] = "pyd",
   ["pyo"] = "pyo",
   ["python"] = "py",
+  ["query"] = "query",
   ["r"] = "r",
   ["rlib"] = "rlib",
   ["rmd"] = "rmd",


### PR DESCRIPTION
Neovim's [`0.8` release](https://github.com/neovim/neovim/releases/tag/v0.8.0) added `query` as a separate filetype from scheme.
I added a little tree to signify it :)



note: I can just link it to scheme if that's more appropriate.