### PR TITLE
fix: update icon for svelte

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -1253,7 +1253,7 @@ local icons_by_file_extension = {
     name = "SystemVerilog",
   },
   ["svelte"] = {
-    icon = "",
+    icon = "",
     color = "#bf2e00",
     cterm_color = "160",
     name = "Svelte",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1286,7 +1286,7 @@ local icons_by_file_extension = {
     name = "SystemVerilog",
   },
   ["svelte"] = {
-    icon = "",
+    icon = "",
     color = "#ff3e00",
     cterm_color = "196",
     name = "Svelte",


### PR DESCRIPTION
Use the proper icon for Svelte. Fixes #91 

<img width="250" alt="Screenshot 2023-03-13 at 19 28 04" src="https://user-images.githubusercontent.com/42694704/224701899-4a4997df-196c-4cb4-9c44-b179fae5f9fa.png">

<img width="250" alt="Screenshot 2023-03-13 at 19 58 26" src="https://user-images.githubusercontent.com/42694704/224708736-500e5352-5503-41d8-9f2d-6fef8784a975.png">