### PR TITLE
feat: let users override icons

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -239,6 +239,7 @@ function M.setup(opts)
   local user_operating_system_icons = user_icons.override_by_operating_system
   local user_desktop_environment_icons = user_icons.override_by_desktop_environment
   local user_window_manager_icons = user_icons.override_by_window_manager
+  local user_icon_overrides = user_icons.override_by_icon
 
   -- filename matches are case insensitive
   lowercase_keys(icons_by_filename)
@@ -253,7 +254,8 @@ function M.setup(opts)
     user_file_ext_icons or {},
     user_operating_system_icons or {},
     user_desktop_environment_icons or {},
-    user_window_manager_icons or {}
+    user_window_manager_icons or {},
+    user_icon_overrides or {}
   )
   global_opts.override = vim.tbl_extend(
     "force",
@@ -263,7 +265,8 @@ function M.setup(opts)
     user_file_ext_icons or {},
     user_operating_system_icons or {},
     user_desktop_environment_icons or {},
-    user_window_manager_icons or {}
+    user_window_manager_icons or {},
+    user_icon_overrides or {}
   )
 
   if user_filename_icons then
@@ -354,6 +357,11 @@ local function get_icon_data(name, ext, opts)
     icon_data = icons_by_filename[name] or get_icon_by_extension(name, ext, opts) or (has_default and default_icon)
   else
     icon_data = icons[name] or get_icon_by_extension(name, ext, opts) or (has_default and default_icon)
+  end
+
+  -- Check for icon override
+  if icon_data and global_opts.override[icon_data.icon] then
+    icon_data = vim.tbl_extend("force", icon_data, global_opts.override[icon_data.icon])
   end
 
   return icon_data

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -191,9 +191,9 @@ local function get_highlight_ctermfg(icon_data)
 
   if vim.fn.has "nvim-0.9" == 1 then
     --- @diagnostic disable-next-line: undefined-field  vim.api.keyset.hl_info specifies cterm, not ctermfg
-    return vim.api.nvim_get_hl(0, { name = higroup, link = false }).ctermfg
+    return tostring(vim.api.nvim_get_hl(0, { name = higroup, link = false }).ctermfg)
   else
-    return vim.api.nvim_get_hl_by_name(higroup, false).foreground ---@diagnostic disable-line: deprecated
+    return tostring(vim.api.nvim_get_hl_by_name(higroup, false).foreground) ---@diagnostic disable-line: deprecated
   end
 end
 


### PR DESCRIPTION
Previously if you wanted to change one icon across several
extensions/filenames you needed to manually override each
instance, now you can target specific icons to simplify
config file.

Basically I'm implementing this feature to match icons to
eza and lazygit, and simplify setup to avoid big config file.

### config file used

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/3973ccc1-2770-4db6-b651-bf94034e95a2) | ![image](https://github.com/user-attachments/assets/86a336f7-5993-4158-ba1a-1a36f0015960) | 

### config file used

```lua
return {
  "nvim-tree/nvim-web-devicons",
  event = "VimEnter",
  opts = {
    override_by_icon = {
      [""] = { icon = "" },
      [""] = { icon = "" },
    },
  },
}
```

Probably it's also a good idea to:
- [ ] override color