### PR TITLE
feat: add racket icon

### DIFF
--- a/lua/nvim-web-devicons/default/icons_by_file_extension.lua
+++ b/lua/nvim-web-devicons/default/icons_by_file_extension.lua
@@ -348,6 +348,7 @@ return {
   ["rb"]             = { icon = "", color = "#701516", cterm_color = "52",  name = "Rb"                         },
   ["res"]            = { icon = "", color = "#CC3E44", cterm_color = "167", name = "ReScript"                   },
   ["resi"]           = { icon = "", color = "#F55385", cterm_color = "204", name = "ReScriptInterface"          },
+  ["rkt"]            = { icon = "󰘧", color = "#9F1D20", cterm_color = "124", name = "Racket"                     },
   ["rlib"]           = { icon = "", color = "#DEA584", cterm_color = "216", name = "Rlib"                       },
   ["rmd"]            = { icon = "", color = "#519ABA", cterm_color = "74",  name = "Rmd"                        },
   ["rproj"]          = { icon = "󰗆", color = "#358A5B", cterm_color = "29",  name = "Rproj"                      },

--- a/lua/nvim-web-devicons/light/icons_by_file_extension.lua
+++ b/lua/nvim-web-devicons/light/icons_by_file_extension.lua
@@ -348,6 +348,7 @@ return { -- this file is generated from lua/nvim-web-devicons/default/icons_by_f
   ["rb"]             = { icon = "", color = "#701516", cterm_color = "52",  name = "Rb"                         },
   ["res"]            = { icon = "", color = "#992E33", cterm_color = "88",  name = "ReScript"                   },
   ["resi"]           = { icon = "", color = "#A33759", cterm_color = "125", name = "ReScriptInterface"          },
+  ["rkt"]            = { icon = "󰘧", color = "#9F1D20", cterm_color = "124", name = "Racket"                     },
   ["rlib"]           = { icon = "", color = "#6F5242", cterm_color = "95",  name = "Rlib"                       },
   ["rmd"]            = { icon = "", color = "#36677C", cterm_color = "24",  name = "Rmd"                        },
   ["rproj"]          = { icon = "󰗆", color = "#286844", cterm_color = "29",  name = "Rproj"                      },


### PR DESCRIPTION
I decided to use the same `nf-custom-scheme` icon that's used for Scheme but with a deep red color similar to the one in the official Racket logo.

<img width="112" height="59" alt="Screenshot_20260202_232751" src="https://github.com/user-attachments/assets/07f868d5-1d94-469c-b433-081ae74f0f9f" />
