### PR TITLE
feat: add svx icon

### DIFF
--- a/lua/nvim-web-devicons/default/icons_by_file_extension.lua
+++ b/lua/nvim-web-devicons/default/icons_by_file_extension.lua
@@ -411,7 +411,7 @@ return {
   ["svg"]            = { icon = "󰜡", color = "#FFB13B", cterm_color = "214", name = "Svg"                        },
   ["svgz"]           = { icon = "󰜡", color = "#FFB13B", cterm_color = "214", name = "Svgz"                       },
   ["svh"]            = { icon = "󰍛", color = "#019833", cterm_color = "28",  name = "SystemVerilog"              },
-  ["svx"]            = { icon = "", color = "#FF0042", cterm_color = "197", name = "Svelte                      Markdown" },
+  ["svx"]            = { icon = "", color = "#FF0042", cterm_color = "197", name = "SvelteMarkdown"             },
   ["swift"]          = { icon = "", color = "#E37933", cterm_color = "166", name = "Swift"                      },
   ["t"]              = { icon = "", color = "#519ABA", cterm_color = "74",  name = "Tor"                        },
   ["tbc"]            = { icon = "󰛓", color = "#1E5CB3", cterm_color = "25",  name = "Tcl"                        },

--- a/lua/nvim-web-devicons/light/icons_by_file_extension.lua
+++ b/lua/nvim-web-devicons/light/icons_by_file_extension.lua
@@ -411,7 +411,7 @@ return { -- this file is generated from lua/nvim-web-devicons/default/icons_by_f
   ["svg"]            = { icon = "󰜡", color = "#80581E", cterm_color = "94",  name = "Svg"                        },
   ["svgz"]           = { icon = "󰜡", color = "#80581E", cterm_color = "94",  name = "Svgz"                       },
   ["svh"]            = { icon = "󰍛", color = "#017226", cterm_color = "22",  name = "SystemVerilog"              },
-  ["svx"]            = { icon = "", color = "#FF0042", cterm_color = "197", name = "Svelte                      Markdown" },
+  ["svx"]            = { icon = "", color = "#FF0042", cterm_color = "197", name = "SvelteMarkdown"             },
   ["swift"]          = { icon = "", color = "#975122", cterm_color = "130", name = "Swift"                      },
   ["t"]              = { icon = "", color = "#36677C", cterm_color = "24",  name = "Tor"                        },
   ["tbc"]            = { icon = "󰛓", color = "#1E5CB3", cterm_color = "25",  name = "Tcl"                        },


### PR DESCRIPTION
Added svelte svx (mdsvex extension)
- added light and default icon
- icons are copied from the svelte file extension
- colors have analogous color shift for distinction
