### PR TITLE
feat: add prefab icon

### DIFF
--- a/lua/nvim-web-devicons/default/icons_by_file_extension.lua
+++ b/lua/nvim-web-devicons/default/icons_by_file_extension.lua
@@ -317,6 +317,7 @@ return {
   ["pp"]             = { icon = "", color = "#FFA61A", cterm_color = "214", name = "Pp"                         },
   ["ppt"]            = { icon = "󰈧", color = "#CB4A32", cterm_color = "160", name = "Ppt"                        },
   ["pptx"]           = { icon = "󰈧", color = "#CB4A32", cterm_color = "160", name = "Pptx"                       },
+  ["prefab"]         = { icon = "", color = "#94D4F9", cterm_color = "117", name = "Prefab"                     },
   ["prisma"]         = { icon = "", color = "#5A67D8", cterm_color = "62",  name = "Prisma"                     },
   ["pro"]            = { icon = "", color = "#E4B854", cterm_color = "179", name = "Prolog"                     },
   ["ps1"]            = { icon = "󰨊", color = "#4273CA", cterm_color = "68",  name = "PsScriptfile"               },

--- a/lua/nvim-web-devicons/light/icons_by_file_extension.lua
+++ b/lua/nvim-web-devicons/light/icons_by_file_extension.lua
@@ -317,6 +317,7 @@ return { -- this file is generated from lua/nvim-web-devicons/default/icons_by_f
   ["pp"]             = { icon = "", color = "#80530D", cterm_color = "94",  name = "Pp"                         },
   ["ppt"]            = { icon = "󰈧", color = "#983826", cterm_color = "124", name = "Ppt"                        },
   ["pptx"]           = { icon = "󰈧", color = "#983826", cterm_color = "124", name = "Pptx"                       },
+  ["prefab"]         = { icon = "", color = "#314753", cterm_color = "238", name = "Prefab"                     },
   ["prisma"]         = { icon = "", color = "#444DA2", cterm_color = "61",  name = "Prisma"                     },
   ["pro"]            = { icon = "", color = "#725C2A", cterm_color = "94",  name = "Prolog"                     },
   ["ps1"]            = { icon = "󰨊", color = "#325698", cterm_color = "25",  name = "PsScriptfile"               },


### PR DESCRIPTION
Add prefab icon, it should look close to unity prefab icon.

### Unity
<img width="698" height="166" alt="image" src="https://github.com/user-attachments/assets/db3ad6dc-0a7f-4c74-b60f-d31f9306c24a" />

### Neovim 
<img width="698" alt="Screenshot 2026-04-27 at 02 57 10" src="https://github.com/user-attachments/assets/2ef974c6-768a-479a-aaa8-8e890cbcd31e" />
