### PR TITLE
fix: use `vim.nonnil` if available

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -272,7 +272,7 @@ function M.has_loaded()
   return loaded
 end
 
-local if_nil = vim.F.if_nil
+local if_nil = vim.nonnil or vim.F.if_nil
 function M.setup(opts)
   if loaded then
     return


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/39495 deprecated `vim.F.if_nil`, so let's use the new API when available to avoid the deprecation warnings.
