### PR TITLE
feat: add asmdef icon

### DIFF
--- a/lua/nvim-web-devicons/default/icons_by_file_extension.lua
+++ b/lua/nvim-web-devicons/default/icons_by_file_extension.lua
@@ -20,6 +20,7 @@ return {
   ["applescript"]    = { icon = "", color = "#6D8085", cterm_color = "66",  name = "AppleScript"                },
   ["asc"]            = { icon = "󰦝", color = "#576D7F", cterm_color = "242", name = "Asc"                        },
   ["asm"]            = { icon = "", color = "#0091BD", cterm_color = "31",  name = "ASM"                        },
+  ["asmdef"]         = { icon = "󰐱", color = "#407AAB", cterm_color = "67",  name = "Asmdef"                     },
   ["ass"]            = { icon = "󰨖", color = "#FFB713", cterm_color = "214", name = "Ass"                        },
   ["astro"]          = { icon = "", color = "#E23F67", cterm_color = "197", name = "Astro"                      },
   ["avi"]            = { icon = "", color = "#FD971F", cterm_color = "208", name = "AudioVideoInterleave"       },

--- a/lua/nvim-web-devicons/light/icons_by_file_extension.lua
+++ b/lua/nvim-web-devicons/light/icons_by_file_extension.lua
@@ -20,6 +20,7 @@ return { -- this file is generated from lua/nvim-web-devicons/default/icons_by_f
   ["applescript"]    = { icon = "", color = "#526064", cterm_color = "59",  name = "AppleScript"                },
   ["asc"]            = { icon = "󰦝", color = "#41525F", cterm_color = "239", name = "Asc"                        },
   ["asm"]            = { icon = "", color = "#006D8E", cterm_color = "24",  name = "ASM"                        },
+  ["asmdef"]         = { icon = "󰐱", color = "#305C80", cterm_color = "24",  name = "Asmdef"                     },
   ["ass"]            = { icon = "󰨖", color = "#805C0A", cterm_color = "94",  name = "Ass"                        },
   ["astro"]          = { icon = "", color = "#AA2F4D", cterm_color = "125", name = "Astro"                      },
   ["avi"]            = { icon = "", color = "#7E4C10", cterm_color = "94",  name = "AudioVideoInterleave"       },


### PR DESCRIPTION
Add `asmdef` icon which is used by Unity Engine for Assembly Definition.

## Unity

<img width="256" alt="image" src="https://github.com/user-attachments/assets/72fd8b32-a89a-4aae-9198-9a65b9678269" />

## Neovim

<img width="256" alt="image" src="https://github.com/user-attachments/assets/133e3e54-4b2b-4f21-b53e-6dedec413578" />
